### PR TITLE
Consolidating common config's

### DIFF
--- a/bundle/client/utils.js
+++ b/bundle/client/utils.js
@@ -1,4 +1,5 @@
 const { DefinePlugin } = require('webpack');
+const { urls, getEnvironment } = require('../../src/configs/config-urls');
 
 const BUILD_BUILDID = process.env.BUILD_BUILDID;
 const DEBUG_BUILD = process.env.DEBUG_BUILD === 'true';
@@ -7,8 +8,8 @@ const IS_AUTOMATION_RUN = process.env.IS_AUTOMATION_RUN;
 
 const showDevtoolBasedOnEnvironment = process.env.NODE_ENV === 'development' || DEBUG_BUILD;
 
-// Define ENVIRONMENT directly matching the logic in src/configs/env.ts
-const ENVIRONMENT = process.env.NODE_ENV === 'development' ? 'integration' : (process.env.NODE_ENV || 'production');
+// Use the shared environment function from config-urls.js
+const ENVIRONMENT = getEnvironment();
 
 const commonPlugins = [
   new DefinePlugin({
@@ -26,8 +27,8 @@ const commonPlugins = [
  */
 async function fetchDynamicConfig() {
   try {
-    // Construct the URL directly since we can't import the TypeScript file
-    const url = `https://1fe-a.akamaihd.net/${ENVIRONMENT}/configs/live.json`;
+    // Use the shared URL configuration with the common environment function
+    const url = urls.dynamicConfig();
     console.log(`Fetching dynamic config from: ${url}`);
     
     const response = await fetch(url);

--- a/bundle/config-urls.js
+++ b/bundle/config-urls.js
@@ -1,0 +1,34 @@
+/**
+ * Common configuration URLs shared between CommonJS and TypeScript modules
+ */
+
+// Replicating the environment logic for compatibility with both environments
+const getEnvironment = () => process.env.NODE_ENV === 'development' ? 'integration' : (process.env.NODE_ENV || 'production');
+
+/**
+ * Base URL for configuration endpoints
+ */
+const getConfigBaseUrl = (env = getEnvironment()) => `https://1fe-a.akamaihd.net/${env}/configs`;
+
+/**
+ * URL endpoints for different configuration types
+ */
+const urls = {
+  dynamicConfig: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/live.json`,
+  widgetVersions: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/widget-versions.json`,
+  libraryVersions: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/lib-versions.json`,
+};
+
+// For CommonJS
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    getConfigBaseUrl,
+    urls,
+  };
+}
+
+// For TypeScript/ES modules
+export {
+  getConfigBaseUrl,
+  urls,
+};

--- a/src/configs/config-urls.d.ts
+++ b/src/configs/config-urls.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Type declarations for config-urls.js
+ */
+
+/**
+ * Get the environment based on NODE_ENV
+ * @returns 'integration' for development, otherwise NODE_ENV or 'production'
+ */
+export function getEnvironment(): string;
+
+/**
+ * Get the base URL for configuration endpoints
+ */
+export function getConfigBaseUrl(env?: string): string;
+
+/**
+ * URL endpoints for different configuration types
+ */
+export const urls: {
+  dynamicConfig: (env?: string) => string;
+  widgetVersions: (env?: string) => string;
+  libraryVersions: (env?: string) => string;
+};

--- a/src/configs/config-urls.js
+++ b/src/configs/config-urls.js
@@ -1,0 +1,26 @@
+/**
+ * Common configuration URLs shared between CommonJS and TypeScript modules
+ */
+
+// Replicating the environment logic for compatibility with both environments
+const getEnvironment = () => process.env.NODE_ENV === 'development' ? 'integration' : (process.env.NODE_ENV || 'production');
+
+/**
+ * Base URL for configuration endpoints
+ */
+const getConfigBaseUrl = (env = getEnvironment()) => `https://1fe-a.akamaihd.net/${env}/configs`;
+
+/**
+ * URL endpoints for different configuration types
+ */
+const urls = {
+  dynamicConfig: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/live.json`,
+  widgetVersions: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/widget-versions.json`,
+  libraryVersions: (env = getEnvironment()) => `${getConfigBaseUrl(env)}/lib-versions.json`,
+};
+
+module.exports = {
+  getConfigBaseUrl,
+  getEnvironment,
+  urls,
+};

--- a/src/configs/ecosystem-configs.ts
+++ b/src/configs/ecosystem-configs.ts
@@ -1,14 +1,15 @@
-import { ENVIRONMENT } from "./env";
+// Use require for CommonJS module
+const { urls } = require("./config-urls");
 
 export const configManagement = {
   widgetVersions: {
-    url: `https://1fe-a.akamaihd.net/${ENVIRONMENT}/configs/widget-versions.json`,
+    url: urls.widgetVersions(),
   },
   libraryVersions: {
-    url: `https://1fe-a.akamaihd.net/${ENVIRONMENT}/configs/lib-versions.json`,
+    url: urls.libraryVersions(),
   },
   dynamicConfigs: {
-    url: `https://1fe-a.akamaihd.net/${ENVIRONMENT}/configs/live.json`
+    url: urls.dynamicConfig()
   },
   refreshMs: 30 * 1000,
 };


### PR DESCRIPTION
Consolidating following common config's so we have one source of truth for config's:
1. Understanding the environment we are running in. 
2. Dynamic config URL's. 

Our build config's are in JS and our source code is in typescript so had to write a commonJS file and import it across both ingestion point's. 