### PR TITLE
fix: replace rimraf with rm -rf in clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "types": "dist/shell/index.d.ts",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "npx rimraf dist",
     "dev": "run-s client:dev server:dev",
     "client:dev": "npx webpack --config ./bundle/client/dev.js",
     "server:dev": "node bundle/server/dev.js",
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@changesets/cli": "^2.29.5",
+    "rimraf": "^6.0.1",
     "@es-exec/esbuild-plugin-start": "^0.0.5",
     "@playwright/test": "^1.51.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",


### PR DESCRIPTION
The rimraf binary was failing with module resolution error during package publishing.
Replacing with native rm -rf command which is more reliable in CI environments.