### PR TITLE
chore: add changeset for patch release testing

### DIFF
--- a/.changeset/patch-release-test.md
+++ b/.changeset/patch-release-test.md
@@ -1,8 +1,0 @@
----
-'@1fe/starter-app': patch
----
-
-chore: manual patch release to test publishing pipeline
-
-This changeset triggers a patch version bump to test the complete 
-CI/CD publishing pipeline with all the recent fixes applied.


### PR DESCRIPTION
- Create manual changeset to trigger patch version bump
- This will test the complete publishing pipeline end-to-end
- Should bump version from 0.0.2 to 0.0.3